### PR TITLE
Add daily news aggregator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # LargeLanguageModel
+
 Spot for ChatGPT to connect
+
+## Daily News Aggregator
+
+`news_fetcher.py` collects news from several RSS feeds and saves a daily report in Markdown.
+
+### Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. (Optional) Configure environment variables for email delivery:
+   - `SMTP_SERVER`
+   - `SMTP_PORT` (default: 587)
+   - `EMAIL_FROM`
+   - `EMAIL_TO`
+   - `EMAIL_PASSWORD`
+
+### Usage
+
+Generate the report without emailing or committing:
+```bash
+python news_fetcher.py --no-email --no-commit
+```
+By default the script saves a file under `news/` named with today's date and commits it to git. Remove `--no-email` or `--no-commit` to enable those features.
+
+### Scheduling
+
+To fetch news daily at 3 PM using cron:
+```cron
+0 15 * * * /usr/bin/python /path/to/news_fetcher.py
+```
+Adjust the path and options as needed. This will generate the report, commit it to the repository, and email a copy if configured.

--- a/news/2025-08-10.md
+++ b/news/2025-08-10.md
@@ -1,0 +1,62 @@
+# Daily News Report - 2025-08-10
+
+## World News
+- [Ukraine's European allies say peace talks must include Kyiv](https://www.bbc.com/news/articles/c0e9py7e28xo?at_medium=RSS&at_campaign=rss) - Sun, 10 Aug 2025 04:20:34 GMT
+- [Vance and Lammy host Ukraine talks ahead of US-Russia summit](https://www.bbc.com/news/articles/c3dp119lk5xo?at_medium=RSS&at_campaign=rss) - Sat, 09 Aug 2025 19:48:13 GMT
+- [Eleven more die from malnutrition in Gaza, Hamas-run health ministry says](https://www.bbc.com/news/articles/c80dpg77g0do?at_medium=RSS&at_campaign=rss) - Sat, 09 Aug 2025 13:42:01 GMT
+- [Thousands protest in Israel over Gaza City occupation plan](https://www.bbc.com/news/videos/c5ylprlr3dzo?at_medium=RSS&at_campaign=rss) - Sun, 10 Aug 2025 02:04:54 GMT
+- [Standing ovation as first female umpire for Major League Baseball takes to the pitch](https://www.bbc.com/news/articles/c62wg6djz35o?at_medium=RSS&at_campaign=rss) - Sun, 10 Aug 2025 00:04:33 GMT
+
+## Australian News
+- [Two Japanese boxers on same card die from brain injuries](https://www.abc.net.au/news/2025-08-10/two-japanese-boxers-on-same-card-die-from-brain-injuries/105634538) - Sun, 10 Aug 2025 06:40:39 +0000
+- [Australian Chamber Orchestra slams ANU plan as 'cultural vandalism'](https://www.abc.net.au/news/2025-08-10/australian-chamber-orchestra-slams-anu-plan-cut-school-of-music/105634030) - Sun, 10 Aug 2025 06:35:28 +0000
+- [RSPCA 'overwhelmed with joy and hope' at end of Tasmanian greyhound racing](https://www.abc.net.au/news/2025-08-10/animal-welfare-advocates-respond-to-tas-greyhound-industry-end/105633902) - Sun, 10 Aug 2025 06:20:14 +0000
+- [Instagram has a new location-sharing feature. But you have to turn it on yourself](https://www.abc.net.au/news/2025-08-10/instagram-new-location-sharing-feature-turning-off/105633766) - Sun, 10 Aug 2025 04:53:20 +0000
+- [Picnic at Hanging Rock is just as unsettling and relevant 50 years on](https://www.abc.net.au/news/2025-08-10/picnic-at-hanging-rock-50-years-old-film/105628154) - Sun, 10 Aug 2025 04:43:06 +0000
+
+## Tucson News
+- [Foul play possible in deaths of couple, dog at northern Arizona home](https://www.kold.com/2025/08/10/foul-play-possible-deaths-couple-dog-northern-arizona-home/) - Sat, 09 Aug 2025 22:13:19 -0700
+- [The historic city of Tombstone celebrates Val Kilmer’s life in weekend-long tribute](https://www.kold.com/2025/08/10/historic-city-tombstone-celebrates-val-kilmers-life-weekend-long-tribute/) - Sat, 09 Aug 2025 21:41:45 -0700
+- [Phoenix suspect in pregnant teen’s murder faces new charges likely linked to 2nd girl](https://www.kold.com/2025/08/10/phoenix-suspect-pregnant-teens-murder-faces-new-charges-likely-linked-2nd-girl/) - Sat, 09 Aug 2025 21:30:53 -0700
+- [5 firefighters hurt in UTV crash while battling Billy Fire](https://www.kold.com/2025/08/05/billy-fire-forces-community-evacuate-tonto-national-forest/) - Sat, 09 Aug 2025 21:27:19 -0700
+- [UPDATE: Tucson Police arrest suspect in deadly shooting at hotel](https://www.kold.com/2025/07/27/tucson-shooting-kills-one-injures-another/) - Sat, 09 Aug 2025 14:40:56 -0700
+- [Tucson leaders look to improve construction jobs following dismissal of Project Blue](https://www.kold.com/2025/08/09/tucson-leaders-look-improve-construction-jobs-following-dismissal-project-blue/) - Sat, 09 Aug 2025 14:02:51 -0700
+- [Tucson councilman tackles shoplifting suspect](https://www.kold.com/2025/08/09/tucson-councilman-tackles-shoplifting-suspect/) - Fri, 08 Aug 2025 22:37:21 -0700
+- [FIRST ALERT FORECAST - So long, Extreme Heat Warning!](https://www.kold.com/2025/08/04/first-alert-forecast-extreme-heat-this-workweek/) - Fri, 08 Aug 2025 22:35:05 -0700
+- [YouTuber may face assault charge following incident in Sahuarita](https://www.kold.com/2025/08/09/youtuber-may-face-assault-charge-following-incident-sahuarita/) - Fri, 08 Aug 2025 21:29:04 -0700
+- [Suspected gunman, officer dead after active shooter alert at Emory University Atlanta campus](https://www.kold.com/2025/08/08/active-shooter-reported-emory-university-atlanta-campus-officials-say/) - Fri, 08 Aug 2025 21:03:28 -0700
+
+## Physics News
+- [Quantum technologies—'Standards currently offer a greater chance of success than regulation,' says researcher](https://phys.org/news/2025-08-quantum-technologies-standards-greater-chance.html) - Fri, 08 Aug 2025 12:33:06 EDT
+- [The US just got a new X-ray laser toolkit to study nature's mysteries](https://phys.org/news/2025-08-ray-laser-toolkit-nature-mysteries.html) - Fri, 08 Aug 2025 11:16:17 EDT
+- [Quantum 'Starry Night': Physicists capture elusive instability and exotic vortices](https://phys.org/news/2025-08-quantum-starry-night-physicists-capture.html) - Fri, 08 Aug 2025 05:00:01 EDT
+- [Researchers overcome long-standing bottleneck in single photon detection with twisted 2D materials](https://phys.org/news/2025-08-bottleneck-photon-2d-materials.html) - Thu, 07 Aug 2025 14:43:44 EDT
+- [Direct visualization of quantum zero-point motion in complex molecule reveals eternal dance of atoms](https://phys.org/news/2025-08-visualization-quantum-motion-complex-molecule.html) - Thu, 07 Aug 2025 14:00:01 EDT
+
+## Science News
+- [Scientists find brain cell switch that could reverse obesity’s effects](https://www.sciencedaily.com/releases/2025/08/250807233048.htm) - Fri, 08 Aug 2025 10:43:20 EDT
+- [New “evolution engine” creates super-proteins 100,000x faster](https://www.sciencedaily.com/releases/2025/08/250807233038.htm) - Fri, 08 Aug 2025 04:59:10 EDT
+- [Nature’s anti-aging hack? Jewel wasp larvae slow their biological clock](https://www.sciencedaily.com/releases/2025/08/250806100753.htm) - Thu, 07 Aug 2025 23:00:34 EDT
+- [Life without sunlight? Earthquake fractures fuel deep underground microbes](https://www.sciencedaily.com/releases/2025/08/250806094130.htm) - Thu, 07 Aug 2025 23:11:34 EDT
+- [The Earth didn’t just crack, it curved. "It sent chills down my spine!"](https://www.sciencedaily.com/releases/2025/08/250806094127.htm) - Wed, 06 Aug 2025 11:58:22 EDT
+
+## Biology News
+- [Scientists say they have solved the mystery of what killed more than 5 billion sea stars](https://phys.org/news/2025-08-scientists-mystery-billion-sea-stars.html) - Sat, 09 Aug 2025 14:40:02 EDT
+- [Sweet disguise: Body hides its own RNA from the immune system with sugar](https://phys.org/news/2025-08-sweet-disguise-body-rna-immune.html) - Sat, 09 Aug 2025 10:30:02 EDT
+- [Great Barrier Reef records largest annual coral loss in 39 years](https://phys.org/news/2025-08-great-barrier-reef-largest-annual.html) - Sat, 09 Aug 2025 05:00:01 EDT
+- [New York declares total war on prolific rat population](https://phys.org/news/2025-08-york-declares-total-war-prolific.html) - Sat, 09 Aug 2025 04:38:53 EDT
+- [AI model enhances crop growth monitoring with minimal field data](https://phys.org/news/2025-08-ai-crop-growth-minimal-field.html) - Fri, 08 Aug 2025 12:32:52 EDT
+
+## AI News
+- [Perplexity accused of scraping websites that explicitly blocked AI scraping](https://techcrunch.com/2025/08/04/perplexity-accused-of-scraping-websites-that-explicitly-blocked-ai-scraping/) - Mon, 04 Aug 2025 15:41:39 +0000
+- [Obvio’s stop sign cameras use AI to root out unsafe drivers](https://techcrunch.com/2025/06/04/obvios-stop-sign-cameras-use-ai-to-root-out-unsafe-drivers/) - Wed, 04 Jun 2025 14:00:00 +0000
+- [Breakneck data center growth challenges Microsoft’s sustainability goals](https://techcrunch.com/2025/06/02/breakneck-data-center-growth-challenges-microsofts-sustainability-goals/) - Mon, 02 Jun 2025 18:07:05 +0000
+- [Gridcare thinks more than 100 GW of data center capacity is hiding in the grid](https://techcrunch.com/2025/05/27/gridcare-thinks-more-than-100-gw-of-data-center-capacity-is-hiding-in-the-grid/) - Tue, 27 May 2025 12:00:00 +0000
+- [Meta adds another 650 MW of solar power to its AI push](https://techcrunch.com/2025/05/22/meta-adds-another-650-mw-of-solar-power-to-its-ai-push/) - Thu, 22 May 2025 16:49:53 +0000
+
+## Technology News
+- [Encryption made for police and military radios may be easily cracked](https://arstechnica.com/security/2025/08/encryption-made-for-police-and-military-radios-may-be-easily-cracked/) - Sat, 09 Aug 2025 11:18:47 +0000
+- [It’s getting harder to skirt RTO policies without employers noticing](https://arstechnica.com/information-technology/2025/08/its-getting-harder-to-skirt-rto-policies-without-employers-noticing/) - Fri, 08 Aug 2025 20:11:56 +0000
+- [Adult sites are stashing exploit code inside racy .svg files](https://arstechnica.com/security/2025/08/adult-sites-use-malicious-svg-files-to-rack-up-likes-on-facebook/) - Fri, 08 Aug 2025 19:41:00 +0000
+- [Google discovered a new scam—and also fell victim to it](https://arstechnica.com/information-technology/2025/08/google-sales-data-breached-in-the-same-scam-it-discovered/) - Thu, 07 Aug 2025 20:05:34 +0000
+- [OpenAI launches GPT-5 free to all ChatGPT users](https://arstechnica.com/ai/2025/08/openai-launches-gpt-5-free-to-all-chatgpt-users/) - Thu, 07 Aug 2025 17:48:57 +0000

--- a/news_fetcher.py
+++ b/news_fetcher.py
@@ -1,0 +1,107 @@
+import argparse
+import os
+import subprocess
+from datetime import datetime
+from email.mime.text import MIMEText
+import smtplib
+from pathlib import Path
+
+import feedparser
+
+# RSS feed configuration: section -> (url, limit)
+FEEDS = {
+    "World News": {"url": "https://feeds.bbci.co.uk/news/world/rss.xml", "limit": 5},
+    "Australian News": {"url": "https://www.abc.net.au/news/feed/51120/rss.xml", "limit": 5},
+    "Tucson News": {"url": "https://www.kold.com/arc/outboundfeeds/rss/category/news/?outputType=xml", "limit": 10},
+    "Physics News": {"url": "https://phys.org/rss-feed/physics-news/", "limit": 5},
+    "Science News": {"url": "https://www.sciencedaily.com/rss/top/science.xml", "limit": 5},
+    "Biology News": {"url": "https://phys.org/rss-feed/biology-news/", "limit": 5},
+    "AI News": {"url": "https://techcrunch.com/tag/artificial-intelligence/feed/", "limit": 5},
+    "Technology News": {"url": "https://feeds.arstechnica.com/arstechnica/technology-lab", "limit": 5},
+}
+
+
+def fetch_feed(url: str, limit: int):
+    """Return list of entries from an RSS feed."""
+    parsed = feedparser.parse(url)
+    entries = []
+    for entry in parsed.entries[:limit]:
+        title = entry.get("title", "No title")
+        link = entry.get("link", "")
+        published = entry.get("published", "")
+        entries.append({"title": title, "link": link, "published": published})
+    return entries
+
+
+def build_report() -> str:
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    lines = [f"# Daily News Report - {date_str}", ""]
+    for section, cfg in FEEDS.items():
+        lines.append(f"## {section}")
+        items = fetch_feed(cfg["url"], cfg["limit"])
+        if not items:
+            lines.append("No news available.\n")
+            continue
+        for item in items:
+            lines.append(f"- [{item['title']}]({item['link']}) - {item['published']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def save_report(content: str, output_dir: str) -> Path:
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    file_path = out_path / f"{date_str}.md"
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return file_path
+
+
+def send_email(subject: str, content: str) -> None:
+    """Send email using environment configuration."""
+    smtp_server = os.environ.get("SMTP_SERVER")
+    smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+    email_from = os.environ.get("EMAIL_FROM")
+    email_to = os.environ.get("EMAIL_TO")
+    password = os.environ.get("EMAIL_PASSWORD")
+    if not all([smtp_server, email_from, email_to, password]):
+        print("Email credentials not fully provided; skipping email.")
+        return
+    msg = MIMEText(content, "plain", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = email_from
+    msg["To"] = email_to
+    with smtplib.SMTP(smtp_server, smtp_port) as server:
+        server.starttls()
+        server.login(email_from, password)
+        server.sendmail(email_from, [email_to], msg.as_string())
+
+
+def git_commit(file_path: Path, message: str) -> None:
+    subprocess.run(["git", "add", str(file_path)], check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch daily news and store as markdown.")
+    parser.add_argument("--output-dir", default="news", help="Directory to store news files")
+    parser.add_argument("--no-email", action="store_true", help="Do not send email")
+    parser.add_argument("--no-commit", action="store_true", help="Do not commit to git")
+    args = parser.parse_args()
+
+    report = build_report()
+    file_path = save_report(report, args.output_dir)
+
+    if not args.no_email:
+        send_email("Daily News Report", report)
+
+    if not args.no_commit:
+        commit_message = f"Add daily news report for {datetime.now().date()}"
+        git_commit(file_path, commit_message)
+
+    print(f"News report saved to {file_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+feedparser>=6.0


### PR DESCRIPTION
## Summary
- add `news_fetcher.py` to gather world, Australian, Tucson, physics, science, biology, AI, and technology RSS headlines
- save reports as dated Markdown files and optionally email/commit them
- document setup, usage, and cron scheduling

## Testing
- `pip install -r requirements.txt`
- `python news_fetcher.py --no-email --no-commit`
- `python -m py_compile news_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68984153ea108328be80c1027e6f2324